### PR TITLE
Pin plette version in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ url = http://github.com/msh5/pipfile-sort
 packages=pipfile_sort
 install_requires=
     click
-    plette
+    plette==0.4.4
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
https://github.com/kwongtn/pipfile-sort/commit/0f6f551c4f226e38bbb86756a3d52bb58043bc68 doesn't apply when the package is installed with pip. It was still getting the 1.x version of plette that isn't compatible.

I _think_ this is the correct syntax for a setup.cfg file. Maybe the next step would be to modernize the use of setuptools, I think pyproject.toml is the preferred thing now.